### PR TITLE
Added IAR EW ROOT variable to list of IAR Platform variables

### DIFF
--- a/Source/cmCoreTryCompile.cxx
+++ b/Source/cmCoreTryCompile.cxx
@@ -69,6 +69,7 @@ static std::set<std::string> ghs_platform_vars{
 
 // IAR platform variables.
 static std::set<std::string> iar_platform_vars{
+    "IAR_EW_ROOT",
     "IAR_SET_INSTALLATION_FOLDER_MANUALLY",
     "IAR_DEBUGGER_LOGFILE",
     "IAR_COMPILER_DLIB_CONFIG",

--- a/Source/cmGlobalIarGenerator.cxx
+++ b/Source/cmGlobalIarGenerator.cxx
@@ -656,6 +656,10 @@ void cmGlobalIarGenerator::Generate()
   flagsWithType = std::string("CMAKE_EXE_LINKER_FLAGS_") + cmSystemTools::UpperCase(GLOBALCFG.buildType);
   GLOBALCFG.iarLinkerFlags = globalMakefile->GetSafeDefinition("CMAKE_EXE_LINKER_FLAGS");
   GLOBALCFG.iarLinkerFlags += std::string(" ") + globalMakefile->GetSafeDefinition(flagsWithType);
+  
+  GLOBALCFG.iarLinkerFlags += std::string(" ") + this->GeneratorTarget->GetProperty("LINK_FLAGS");
+  std::string configLinkFlags = "LINK_FLAGS_" + cmSystemTools::UpperCase(GLOBALCFG.buildType);
+  GLOBALCFG.iarLinkerFlags += std::string(" ") + this->GeneratorTarget->GetProperty(configLinkFlags);
 
   GLOBALCFG.compilerDlibConfig =
       globalMakefile->GetSafeDefinition("IAR_COMPILER_DLIB_CONFIG");


### PR DESCRIPTION
This variable is used during try-copile execution for determining which options needs to be always copied. This variable ensures that try compile will run with the same version of IAR as the rest of the project in case multiple IAR instalations are present.
